### PR TITLE
Add support for inline_message_id-based hydration

### DIFF
--- a/src/data/callback-query.ts
+++ b/src/data/callback-query.ts
@@ -1,5 +1,9 @@
 import { CallbackQuery, RawApi } from "../deps.deno.ts";
 import { Other, Ret } from "../plugin.ts";
+import {
+    InlineMessageXFragment,
+    installInlineMessageMethods,
+} from "./inline-message.ts";
 import { installMessageMethods, MessageX } from "./message.ts";
 
 interface CallbackQueryXFragment {
@@ -21,7 +25,10 @@ interface CallbackQueryXFragment {
     ): Ret<"answerCallbackQuery">;
 }
 
-export type CallbackQueryX = CallbackQueryXFragment & CallbackQuery;
+export type CallbackQueryX =
+    & CallbackQueryXFragment
+    & Partial<InlineMessageXFragment>
+    & CallbackQuery;
 
 export function installCallbackQueryMethods(
     api: RawApi,
@@ -29,6 +36,10 @@ export function installCallbackQueryMethods(
 ) {
     if (callbackQuery.message !== undefined) {
         installMessageMethods(api, callbackQuery.message);
+    } else if (callbackQuery.inline_message_id !== undefined) {
+        installInlineMessageMethods(api, {
+            inline_message_id: callbackQuery.inline_message_id,
+        });
     }
 
     const methods: Omit<CallbackQueryXFragment, "message"> = {

--- a/src/data/chosen-inline-result.ts
+++ b/src/data/chosen-inline-result.ts
@@ -1,0 +1,20 @@
+import { ChosenInlineResult, RawApi } from "../deps.deno.ts";
+import {
+    InlineMessageXFragment,
+    installInlineMessageMethods,
+} from "./inline-message.ts";
+
+export type ChosenInlineResultX =
+    & Partial<InlineMessageXFragment>
+    & ChosenInlineResult;
+
+export function installChosenInlineResultMethods(
+    api: RawApi,
+    chosenInlineResult: ChosenInlineResult,
+) {
+    if (chosenInlineResult.inline_message_id !== undefined) {
+        installInlineMessageMethods(api, {
+            inline_message_id: chosenInlineResult.inline_message_id,
+        });
+    }
+}

--- a/src/data/inline-message.ts
+++ b/src/data/inline-message.ts
@@ -1,0 +1,163 @@
+import {
+    InlineKeyboardMarkup,
+    InputFile,
+    InputFileProxy,
+    RawApi,
+    SentWebAppMessage,
+} from "../deps.deno.ts";
+import { Other as O, Ret } from "../plugin.ts";
+type Other<M extends keyof RawApi, K extends string = never> = O<
+    M,
+    K | "chat_id" | "message_id"
+>;
+
+export interface InlineMessageXFragment {
+    /**
+     * Message-aware alias for `api.editMessageReplyMarkup`. Use this method to edit only the reply markup of messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
+     *
+     * @param reply_markup An object for an inline keyboard.
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#editmessagereplymarkup
+     */
+    editReplyMarkup(
+        reply_markup?: InlineKeyboardMarkup,
+        signal?: AbortSignal,
+    ): Ret<"editMessageReplyMarkup">;
+
+    /**
+     * Message-aware alias for `api.editMessageText`. Use this method to edit text and game messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
+     *
+     * @param text New text of the message, 1-4096 characters after entities parsing
+     * @param other Optional remaining parameters, confer the official reference below
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#editmessagetext
+     */
+    editText(
+        text: string,
+        other?: Other<"editMessageText", "text">,
+        signal?: AbortSignal,
+    ): Ret<"editMessageText">;
+
+    /**
+     * Message-aware alias for `api.editMessageLiveLocation`. Use this method to edit live location messages. A location can be edited until its live_period expires or editing is explicitly disabled by a call to stopMessageLiveLocation. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
+     *
+     * @param latitude Latitude of new location
+     * @param longitude Longitude of new location
+     * @param other Optional remaining parameters, confer the official reference below
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#editmessagelivelocation
+     */
+    editLiveLocation(
+        latitude: number,
+        longitude: number,
+        other?: Other<
+            "editMessageLiveLocation",
+            "inline_message_id" | "latitude" | "longitude"
+        >,
+        signal?: AbortSignal,
+    ): Ret<"editMessageLiveLocation">;
+
+    /**
+     * Message-aware alias for `api.stopMessageLiveLocation`. Use this method to stop updating a live location message before live_period expires. On success, if the message is not an inline message, the edited Message is returned, otherwise True is returned.
+     *
+     * @param other Optional remaining parameters, confer the official reference below
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#stopmessagelivelocation
+     */
+    stopLiveLocation(
+        other?: Other<"stopMessageLiveLocation", "inline_message_id">,
+        signal?: AbortSignal,
+    ): Ret<"stopMessageLiveLocation">;
+
+    /**
+     * Message-aware alias for `api.editMessageCaption`. Use this method to edit captions of messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
+     *
+     * @param caption New caption of the message, 0-1024 characters after entities parsing
+     * @param other Optional remaining parameters, confer the official reference below
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#editmessagecaption
+     */
+    editCaption(
+        caption?: string,
+        other?: Other<"editMessageCaption", "inline_message_id" | "caption">,
+        signal?: AbortSignal,
+    ): Ret<"editMessageCaption">;
+
+    /**
+     * Message-aware alias for `api.editMessageMedia`. Use this method to edit animation, audio, document, photo, or video messages. If a message is part of a message album, then it can be edited only to an audio for audio albums, only to a document for document albums and to a photo or a video otherwise. When an inline message is edited, a new file can't be uploaded; use a previously uploaded file via its file_id or specify a URL. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
+     *
+     * @param media An object for a new media content of the message
+     * @param other Optional remaining parameters, confer the official reference below
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#editmessagemedia
+     */
+    editMedia(
+        media: InputFileProxy<InputFile>["InputMedia"],
+        other?: Other<"editMessageMedia", "inline_message_id" | "media">,
+        signal?: AbortSignal,
+    ): Ret<"editMessageMedia">;
+}
+
+export type InlineMessageX = InlineMessageXFragment & SentWebAppMessage;
+
+export function installInlineMessageMethods(
+    api: RawApi,
+    message: SentWebAppMessage,
+) {
+    const methods: InlineMessageXFragment = {
+        editReplyMarkup: (reply_markup, signal) =>
+            api.editMessageReplyMarkup(
+                { inline_message_id: message.inline_message_id, reply_markup },
+                signal,
+            ),
+        editText: (text, other, signal) =>
+            api.editMessageText(
+                {
+                    inline_message_id: message.inline_message_id,
+                    text,
+                    ...other,
+                },
+                signal,
+            ),
+        editLiveLocation: (latitude, longitude, other, signal) =>
+            api.editMessageLiveLocation(
+                {
+                    inline_message_id: message.inline_message_id,
+                    latitude,
+                    longitude,
+                    ...other,
+                },
+                signal,
+            ),
+        stopLiveLocation: (other, signal) =>
+            api.stopMessageLiveLocation(
+                { inline_message_id: message.inline_message_id, ...other },
+                signal,
+            ),
+        editCaption: (caption, other, signal) =>
+            api.editMessageCaption(
+                {
+                    inline_message_id: message.inline_message_id,
+                    caption,
+                    ...other,
+                },
+                signal,
+            ),
+        editMedia: (media, other, signal) =>
+            api.editMessageMedia(
+                {
+                    inline_message_id: message.inline_message_id,
+                    media,
+                    ...other,
+                },
+                signal,
+            ),
+    };
+    Object.assign(message, methods);
+}

--- a/src/data/message.ts
+++ b/src/data/message.ts
@@ -1,17 +1,12 @@
-import {
-    InlineKeyboardMarkup,
-    InputFile,
-    InputFileProxy,
-    Message,
-    RawApi,
-} from "../deps.deno.ts";
+import { Message, RawApi } from "../deps.deno.ts";
+import { InlineMessageXFragment } from "./inline-message.ts";
 import { Other as O, Ret } from "../plugin.ts";
 type Other<M extends keyof RawApi, K extends string = never> = O<
     M,
     K | "chat_id" | "message_id"
 >;
 
-interface MessageXFragment {
+interface MessageXFragment extends InlineMessageXFragment {
     /**
      * Message-aware alias for `api.forwardMessage`. Use this method to forward messages of any kind. Service messages can't be forwarded. On success, the sent Message is returned.
      *
@@ -58,97 +53,6 @@ interface MessageXFragment {
      * **Official reference:** https://core.telegram.org/bots/api#deletemessage
      */
     delete(signal?: AbortSignal): Ret<"deleteMessage">;
-
-    /**
-     * Message-aware alias for `api.editMessageReplyMarkup`. Use this method to edit only the reply markup of messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
-     *
-     * @param reply_markup An object for an inline keyboard.
-     * @param signal Optional `AbortSignal` to cancel the request
-     *
-     * **Official reference:** https://core.telegram.org/bots/api#editmessagereplymarkup
-     */
-    editReplyMarkup(
-        reply_markup?: InlineKeyboardMarkup,
-        signal?: AbortSignal,
-    ): Ret<"editMessageReplyMarkup">;
-
-    /**
-     * Message-aware alias for `api.editMessageText`. Use this method to edit text and game messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
-     *
-     * @param text New text of the message, 1-4096 characters after entities parsing
-     * @param other Optional remaining parameters, confer the official reference below
-     * @param signal Optional `AbortSignal` to cancel the request
-     *
-     * **Official reference:** https://core.telegram.org/bots/api#editmessagetext
-     */
-    editText(
-        text: string,
-        other?: Other<"editMessageText", "text">,
-        signal?: AbortSignal,
-    ): Ret<"editMessageText">;
-
-    /**
-     * Message-aware alias for `api.editMessageLiveLocation`. Use this method to edit live location messages. A location can be edited until its live_period expires or editing is explicitly disabled by a call to stopMessageLiveLocation. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
-     *
-     * @param latitude Latitude of new location
-     * @param longitude Longitude of new location
-     * @param other Optional remaining parameters, confer the official reference below
-     * @param signal Optional `AbortSignal` to cancel the request
-     *
-     * **Official reference:** https://core.telegram.org/bots/api#editmessagelivelocation
-     */
-    editLiveLocation(
-        latitude: number,
-        longitude: number,
-        other?: Other<
-            "editMessageLiveLocation",
-            "inline_message_id" | "latitude" | "longitude"
-        >,
-        signal?: AbortSignal,
-    ): Ret<"editMessageLiveLocation">;
-
-    /**
-     * Message-aware alias for `api.stopMessageLiveLocation`. Use this method to stop updating a live location message before live_period expires. On success, if the message is not an inline message, the edited Message is returned, otherwise True is returned.
-     *
-     * @param other Optional remaining parameters, confer the official reference below
-     * @param signal Optional `AbortSignal` to cancel the request
-     *
-     * **Official reference:** https://core.telegram.org/bots/api#stopmessagelivelocation
-     */
-    stopLiveLocation(
-        other?: Other<"stopMessageLiveLocation", "inline_message_id">,
-        signal?: AbortSignal,
-    ): Ret<"stopMessageLiveLocation">;
-
-    /**
-     * Message-aware alias for `api.editMessageCaption`. Use this method to edit captions of messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
-     *
-     * @param caption New caption of the message, 0-1024 characters after entities parsing
-     * @param other Optional remaining parameters, confer the official reference below
-     * @param signal Optional `AbortSignal` to cancel the request
-     *
-     * **Official reference:** https://core.telegram.org/bots/api#editmessagecaption
-     */
-    editCaption(
-        caption?: string,
-        other?: Other<"editMessageCaption", "inline_message_id" | "caption">,
-        signal?: AbortSignal,
-    ): Ret<"editMessageCaption">;
-
-    /**
-     * Message-aware alias for `api.editMessageMedia`. Use this method to edit animation, audio, document, photo, or video messages. If a message is part of a message album, then it can be edited only to an audio for audio albums, only to a document for document albums and to a photo or a video otherwise. When an inline message is edited, a new file can't be uploaded; use a previously uploaded file via its file_id or specify a URL. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
-     *
-     * @param media An object for a new media content of the message
-     * @param other Optional remaining parameters, confer the official reference below
-     * @param signal Optional `AbortSignal` to cancel the request
-     *
-     * **Official reference:** https://core.telegram.org/bots/api#editmessagemedia
-     */
-    editMedia(
-        media: InputFileProxy<InputFile>["InputMedia"],
-        other?: Other<"editMessageMedia", "inline_message_id" | "media">,
-        signal?: AbortSignal,
-    ): Ret<"editMessageMedia">;
 }
 
 export type MessageX = MessageXFragment & Message;

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -1,9 +1,22 @@
 import { RawApi, Update } from "../deps.deno.ts";
-import { CallbackQueryX, installCallbackQueryMethods } from "./callback-query.ts";
+import {
+    CallbackQueryX,
+    installCallbackQueryMethods,
+} from "./callback-query.ts";
 import { InlineQueryX, installInlineQueryMethods } from "./inline-query.ts";
-import { installPreCheckoutQueryMethods, PreCheckoutQueryX } from "./pre-checkout-query.ts";
-import { installShippingQueryMethods, ShippingQueryX } from "./shipping-query.ts";
+import {
+    installPreCheckoutQueryMethods,
+    PreCheckoutQueryX,
+} from "./pre-checkout-query.ts";
+import {
+    installShippingQueryMethods,
+    ShippingQueryX,
+} from "./shipping-query.ts";
 import { installMessageMethods, MessageX } from "./message.ts";
+import {
+    ChosenInlineResultX,
+    installChosenInlineResultMethods,
+} from "./chosen-inline-result.ts";
 
 export interface UpdateX extends Update {
     message: MessageX | undefined;
@@ -14,6 +27,7 @@ export interface UpdateX extends Update {
     callback_query: CallbackQueryX | undefined;
     shipping_query: ShippingQueryX | undefined;
     pre_checkout_query: PreCheckoutQueryX | undefined;
+    chosen_inline_result: ChosenInlineResultX | undefined;
 }
 
 export function installUpdateMethods(api: RawApi, update: Update) {
@@ -33,5 +47,7 @@ export function installUpdateMethods(api: RawApi, update: Update) {
         installShippingQueryMethods(api, update.shipping_query);
     } else if (update.pre_checkout_query !== undefined) {
         installPreCheckoutQueryMethods(api, update.pre_checkout_query);
+    } else if (update.chosen_inline_result !== undefined) {
+        installChosenInlineResultMethods(api, update.chosen_inline_result);
     }
 }

--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -2,10 +2,10 @@ export {
     Api,
     Context,
     InputFile,
-} from "https://lib.deno.dev/x/grammy@v1/mod.ts";
+} from "https://raw.githubusercontent.com/grammyjs/grammY/fe187959320eea64d1c9e9444d14fe3c3cebeb8d/src/mod.ts";
 export type {
     ApiCallFn,
     RawApi,
     Transformer,
-} from "https://lib.deno.dev/x/grammy@v1/mod.ts";
-export * from "https://cdn.skypack.dev/@grammyjs/types@v2?dts";
+} from "https://raw.githubusercontent.com/grammyjs/grammY/fe187959320eea64d1c9e9444d14fe3c3cebeb8d/src/mod.ts";
+export * from "https://esm.sh/@grammyjs/types@v2";


### PR DESCRIPTION
Blocked by https://github.com/grammyjs/grammY/pull/187

Adds support for messages with `inline_message_id` that are returned from API calls. Those are the only API calls that actually return a message with an inline message identifier.

Now that we have it, we can reuse it for callback queries as well as chosen inline results.