### PR TITLE
fix: only use types form /types

### DIFF
--- a/src/deps.node.ts
+++ b/src/deps.node.ts
@@ -7,4 +7,4 @@ export {
     RawApi,
     Transformer,
 } from "grammy";
-export * from "grammy/types";
+export type * from "grammy/types";


### PR DESCRIPTION
It is not possible to import JS files via `grammy/types` for good reason. This plugin needs to respect that. That will fix #24.